### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ See the introduction vignette for details.
 
 ## Reference
 
-Henden L, Lee S, Mueller I, Barry A, Bahlo M. 2016. Identity-by-descent analyses for measuring population dynamics and selection in recombining pathogens. *bioRxiv*. doi: http://dx.doi.org/10.1101/088039
+Henden L, Lee S, Mueller I, Barry A, Bahlo M. 2016. Identity-by-descent analyses for measuring population dynamics and selection in recombining pathogens. *bioRxiv*. doi: https://doi.org/10.1101/088039

--- a/docs/README.html
+++ b/docs/README.html
@@ -128,7 +128,7 @@ devtools::install_github("bahlolab/isoRelate")</code></pre>
 <div id="reference" class="section level2">
 <h2 class="hasAnchor">
 <a href="#reference" class="anchor"></a>Reference</h2>
-<p>Henden L, Lee S, Mueller I, Barry A, Bahlo M. 2016. Identity-by-descent analyses for measuring population dynamics and selection in recombining pathogens. <em>bioRxiv</em>. doi: <a href="http://dx.doi.org/10.1101/088039" class="uri">http://dx.doi.org/10.1101/088039</a></p>
+<p>Henden L, Lee S, Mueller I, Barry A, Bahlo M. 2016. Identity-by-descent analyses for measuring population dynamics and selection in recombining pathogens. <em>bioRxiv</em>. doi: <a href="https://doi.org/10.1101/088039" class="uri">https://doi.org/10.1101/088039</a></p>
 </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -101,7 +101,7 @@ devtools::install_github("bahlolab/isoRelate")</code></pre>
 <div id="reference" class="section level2">
 <h2 class="hasAnchor">
 <a href="#reference" class="anchor"></a>Reference</h2>
-<p>Henden L, Lee S, Mueller I, Barry A, Bahlo M. 2016. Identity-by-descent analyses for measuring population dynamics and selection in recombining pathogens. <em>bioRxiv</em>. doi: <a href="http://dx.doi.org/10.1101/088039" class="uri">http://dx.doi.org/10.1101/088039</a></p>
+<p>Henden L, Lee S, Mueller I, Barry A, Bahlo M. 2016. Identity-by-descent analyses for measuring population dynamics and selection in recombining pathogens. <em>bioRxiv</em>. doi: <a href="https://doi.org/10.1101/088039" class="uri">https://doi.org/10.1101/088039</a></p>
 </div>
 </div>
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!